### PR TITLE
List support

### DIFF
--- a/app/assets/javascripts/dante/editor.js.coffee
+++ b/app/assets/javascripts/dante/editor.js.coffee
@@ -151,7 +151,7 @@ class Dante.Editor extends Dante.View
     range = range || this.current_range
     if !range
       range = this.getRange()
-      range.collapse(false); # set to end
+      range.collapse(false) # set to end
 
     @selection().removeAllRanges()
     @selection().addRange(range)
@@ -588,6 +588,12 @@ class Dante.Editor extends Dante.View
 
     if e.which == 13
 
+      
+      if $node.hasClass("graf--p")
+        @handleSmartList($node, e)
+      else if $node.hasClass("graf--li") and ($node.text() is "")
+        @handleListLineBreak($node, e)
+    
       #removes previous selected nodes
       $(@el).find(".is-selected").removeClass("is-selected")
 
@@ -1059,41 +1065,42 @@ class Dante.Editor extends Dante.View
       match = $item.text().match(/^\s*1(\.|\))\s*/)
       if(match)
         utils.log("CREATING LIST ITEM");
-        e.preventDefault();
-        this.listify($item, "ol", match[0].length);
+        e.preventDefault()
+        this.listify($item, "ol", match[0].length)
 
   handleListLineBreak: ($li, e)->
     utils.log("LIST LINE BREAK")
     e.preventDefault()
-    @tooptip_view.hide()
+    @tooltip_view.hide()
     $list = $li.parent("ol, ul")
     $paragraph = $("<p></p>")
     if($list.children().length == 1)
       @replaceWith("p", $list)
     else if ($li.next().length == 0 and $li.text() == "")
-      $list.after($paragraph);
-      $li.remove();
+      $list.after($paragraph)
+      $li.remove()
 
-      @addClassesToElement($paragraph[0]);
-      @setRangeAt($paragraph[0]);
-      @markAsSelected($paragraph[0]);
-      @scrollTo($paragraph); 
+      @addClassesToElement($paragraph[0])
+      @setRangeAt($paragraph[0])
+      @markAsSelected($paragraph[0])
+      @scrollTo($paragraph) 
 
   handleListBackspace: ($li, e)->
     
-    $list = $li.parent("ol, ul");
-    utils.log("LIST BACKSPACE");
+    $list = $li.parent("ol, ul")
+    utils.log("LIST BACKSPACE")
 
     if($li.prev().length is 0)
-      e.preventDefault();
+      e.preventDefault()
 
-      $list.before($li);
-      content = $li.html();
-      @replaceWith("p", $li);
-      $paragraph = $(".is-selected");
-      $paragraph.removeClass("graf--empty").html(content);
+      $list.before($li)
+      content = $li.html()
+      @replaceWith("p", $li)
+      $paragraph = $(".is-selected")
+      $paragraph.removeClass("graf--empty").html(content)
 
       if($list.children().length is 0)
-        $list.remove();
+        $list.remove()
       
-      @setupFirstAndLast();
+      @setupFirstAndLast()
+      

--- a/app/assets/javascripts/dante/menu.js.coffee
+++ b/app/assets/javascripts/dante/menu.js.coffee
@@ -196,6 +196,9 @@ class Dante.Editor.Menu extends Dante.View
       if tag.match /(?:h[1-6])/i
         $(@el).find(".icon-bold, .icon-italic, .icon-blockquote")
         .parent("li").remove()
+      else if tag is "indent"
+        $(@el).find(".icon-h2, .icon-h3, .icon-h4, .icon-blockquote")
+        .parent("li").remove()
         #.parent("li").hide()
         #.addClass("hidden")
 

--- a/app/assets/stylesheets/dante/_graf.scss
+++ b/app/assets/stylesheets/dante/_graf.scss
@@ -13,6 +13,10 @@
   margin: 0;
 }
 
+.postList {
+  margin-bottom: 30px; 
+}
+
 .graf--p,
 .graf--blockquote,
 .graf--pullquote {

--- a/bower.json~
+++ b/bower.json~
@@ -1,0 +1,44 @@
+{
+  "name" : "dante",
+  "description": "Just another Medium editor clone.",
+  "homepage": "michelson.github.io/Dante/",
+  "version" : "0.0.7",
+  "keywords": [
+    "css",
+    "sass",
+    "js",
+    "coffeescript",
+    "medium",
+    "editor",
+    "web",
+    "wysiwyg"
+  ],
+  "authors": [
+    { "name": "Miguel Michelson", "homepage": "https://github.com/michelson" },
+    { "name": "Cristian Ferrari", "homepage": "https://github.com/cristianferrarig" }
+  ],
+  "main": [
+    "app/assets/**/*",
+    "dist/**/*"
+  ],
+  "ignore": [
+    ".gitignore",
+    ".travis.yml",
+    ".ruby-version",
+    "config.*",
+    "dante-editor.gemspec",
+    "Gemfile",
+    "Gemfile.lock",
+    "Procfile",
+    "rakefile",
+    "ROADMAP.md",
+    "TODO.md",
+    "lib",
+    "source"
+  ],
+  "dependencies": {
+    "jquery": "https://github.com/jquery/jquery.git",
+    "underscore" : "https://github.com/jashkenas/underscore.git",,
+    "sanitize.js" : "https://github.com/gbirke/Sanitize.js.git"
+  }
+}

--- a/dist/0.0.7/css/dante-editor.css
+++ b/dist/0.0.7/css/dante-editor.css
@@ -658,9 +658,6 @@
 .graf--pre {
   margin: 0; }
 
-.postList {
-  margin-bottom: 30px; 
-  }
 /* line 16, /Users/michelsonmartinez/Documents/rubyonrails/medium-editor/app/assets/stylesheets/dante/_graf.scss */
 .graf--p,
 .graf--blockquote,

--- a/dist/0.0.7/js/dante-editor.js
+++ b/dist/0.0.7/js/dante-editor.js
@@ -709,11 +709,12 @@
         node = node.parentNode;
       }
 
-/*    lists are not graf elements, and thus must be skipped over
-      while (node && (node.parentNode !== root)) {
-        node = node.parentNode;
+      //With the modification to the line above, Im not sure this loop is even necessary
+      if(!$(node).hasClass("graf--li")){
+        while (node && (node.parentNode !== root)) {
+          node = node.parentNode;
+        }
       }
-*/
       if (root && root.contains(node)) {
         return node;
       } else {
@@ -1652,6 +1653,10 @@
     
     //wrap the list item in the proper list, then focus on it
     $li.html(content).wrap($list);
+
+    if($li.find("br").length === 0){
+      $li.append("<br/>");
+    }
     this.setRangeAt($li[0], 0);
     this.scrollTo($li[0]);
   }
@@ -1680,7 +1685,7 @@
   
     //check if an ordered list should be entered
     else{
-      match = $node.text().match(/^\s*1(\.|\))\s+/);
+      match = $node.text().match(/^\s*1(\.|\))\s*/);
       if(match){
       
         //replace default action with ordered list insertion

--- a/dist/0.0.7/js/dante-editor.js
+++ b/dist/0.0.7/js/dante-editor.js
@@ -1383,7 +1383,7 @@
         case "ul":
           $(n).removeClass().addClass("postList");
           _.each($(n).find("li"), function(li) {
-            return $(n).removeClass().addClass("graf graf--li");
+            return li.removeClass().addClass("graf graf--li");
           });
           break;
         case "img":
@@ -1612,12 +1612,9 @@
   /**
   * Takes a paragraph and makes a list out of it
   *
-  * PAGAN CODE: This function assumes Dante does not natively support adding lists.
-  *             It may interfere with updates that add native list features
-  *
   * @param {jQuery} paragraph The paragraph to listify
   * @param {string} list_type The type of list (ol or ul)
-  * @param {int}    tagLength The Length of the 
+  * @param {int}    tagLength The Length of the smartlist trigger string
   *
   * @return false if list_type is not ol or ul. Otherwise, the new list is returned
   */
@@ -1696,21 +1693,41 @@
   }
   
 
-  Editor.prototype.handleListLineBreak = function($node, e){
+  /**
+  * Handles the processing of line breaks when in a list
+  *
+  * @param {jQuery} $li - The list item where a line break was entered
+  * @param {event}  e   - The event that generates the line break
+  *
+  */
+  Editor.prototype.handleListLineBreak = function($li, e){
+    var $list, $parahraph;
+
     utils.log("LIST LINE BREAK HANDLE");
     e.preventDefault();
     this.tooltip_view.hide();
-    var $list = $($node.parent("ol, ul")[0]);
-    var $paragraph = $("<p></p>"); 
+
+    //get the list containing the selected list item
+    $list = $($li.parent("ol, ul")[0]);
+
+    //generate replacement paragraph
+    $paragraph = $("<p></p>"); 
     
+
+    //if the list has only one child, replace it with a paragraph
     if($list.children().length === 1){
       this.replaceWith("p", $list);
       
     }
     
-    else if($node.next().length == 0 && $node.text() === ""){
+    //if the list item is the last child and is empty
+    else if($li.next().length == 0 && $li.text() === ""){
+
+      //put the replacement paragraph after the list and remove the empty list item
       $list.after($paragraph);
-      $node.remove();
+      $li.remove();
+
+      //select and focu on the new paragraph
       this.addClassesToElement($paragraph[0]);
       this.setRangeAt($paragraph[0]);
       this.markAsSelected($paragraph[0]);
@@ -1718,28 +1735,39 @@
     }
   }
 
+  /**
+  * Handles backspace keydowns in lists
+  *
+  * @param {jQuery} $li - The list item where backspace was pressed
+  * @param {event}  e   - The backspace event object
+  *
+  */
   Editor.prototype.handleListBackspace = function($li, e){
     
     var content, $list, $paragraph;
 
+    //get the list item's parent list
     $list = $li.parent("ol, ul");
     utils.log("LIST BACKSPACE");
 
+    //if on the first list item of a list
     if($li.prev().length === 0){
       e.preventDefault();
+
+      //move the item outside of the list, and replace it with a paragraph
       $list.before($li);
       content = $li.html();
       this.replaceWith("p", $li);
       $paragraph = $(".is-selected");
       $paragraph.removeClass("graf--empty").html(content);
 
+      //then, if the list is empty, remove it
       if($list.children().length === 0){
         $list.remove();
       }
 
+      //set up first and last attributes
       this.setupFirstAndLast();
-
-      return;
     }
   }
 

--- a/dist/0.0.7/js/dante-editor.js
+++ b/dist/0.0.7/js/dante-editor.js
@@ -1732,7 +1732,7 @@
       $list.after($paragraph);
       $li.remove();
 
-      //select and focu on the new paragraph
+      //select and focus on the new paragraph
       this.addClassesToElement($paragraph[0]);
       this.setRangeAt($paragraph[0]);
       this.markAsSelected($paragraph[0]);

--- a/dist/0.0.7/js/dante-editor.js
+++ b/dist/0.0.7/js/dante-editor.js
@@ -2572,6 +2572,9 @@
           if (tag.match(/(?:h[1-6])/i)) {
             $(_this.el).find(".icon-bold, .icon-italic, .icon-blockquote").parent("li").remove();
           }
+          else if(tag === "indent"){
+            $(_this.el).find(".icon-h2, .icon-h3, .icon-h4, .icon-blockquote").parent("li").remove();
+          }
           return _this.highlight(tag);
         };
       })(this));

--- a/dist/0.0.7/js/dante-editor.js
+++ b/dist/0.0.7/js/dante-editor.js
@@ -1177,6 +1177,10 @@
         utils.log("pass initial validations");
         anchor_node = this.getNode();
         utils_anchor_node = utils.getNode();
+
+        if($node.hasClass("graf--li") && this.getCharacterPrecedingCaret().length === 0){
+          return this.handleListBackspace($node, e);
+        }
         if ($(utils_anchor_node).hasClass("section-content") || $(utils_anchor_node).hasClass("graf--first")) {
           utils.log("SECTION DETECTED FROM KEYDOWN " + (_.isEmpty($(utils_anchor_node).text())));
           if (_.isEmpty($(utils_anchor_node).text())) {
@@ -1306,6 +1310,7 @@
     Editor.prototype.replaceWith = function(element_type, from_element) {
       var new_paragraph;
       new_paragraph = $("<" + element_type + " class='graf graf--" + element_type + " graf--empty is-selected'><br/></" + element_type + ">");
+      this.setElementName(new_paragraph);
       from_element.replaceWith(new_paragraph);
       this.setRangeAt(new_paragraph[0]);
       this.scrollTo(new_paragraph);
@@ -1710,6 +1715,31 @@
       this.setRangeAt($paragraph[0]);
       this.markAsSelected($paragraph[0]);
       return this.scrollTo($paragraph); 
+    }
+  }
+
+  Editor.prototype.handleListBackspace = function($li, e){
+    
+    var content, $list, $paragraph;
+
+    $list = $li.parent("ol, ul");
+    utils.log("LIST BACKSPACE");
+
+    if($li.prev().length === 0){
+      e.preventDefault();
+      $list.before($li);
+      content = $li.html();
+      this.replaceWith("p", $li);
+      $paragraph = $(".is-selected");
+      $paragraph.removeClass("graf--empty").html(content);
+
+      if($list.children().length === 0){
+        $list.remove();
+      }
+
+      this.setupFirstAndLast();
+
+      return;
     }
   }
 

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,255 @@
+0 info it worked if it ends with ok
+1 verbose cli [ 'node', '/usr/local/bin/npm', 'install', '-g', 'bower' ]
+2 info using npm@1.4.28
+3 info using node@v0.10.35
+4 verbose cache add [ 'bower', null ]
+5 verbose cache add name=undefined spec="bower" args=["bower",null]
+6 verbose parsed url { protocol: null,
+6 verbose parsed url   slashes: null,
+6 verbose parsed url   auth: null,
+6 verbose parsed url   host: null,
+6 verbose parsed url   port: null,
+6 verbose parsed url   hostname: null,
+6 verbose parsed url   hash: null,
+6 verbose parsed url   search: null,
+6 verbose parsed url   query: null,
+6 verbose parsed url   pathname: 'bower',
+6 verbose parsed url   path: 'bower',
+6 verbose parsed url   href: 'bower' }
+7 silly lockFile 206e3ce5-bower bower
+8 verbose lock bower /Users/Gandhi/.npm/206e3ce5-bower.lock
+9 silly lockFile 206e3ce5-bower bower
+10 silly lockFile 206e3ce5-bower bower
+11 verbose addNamed [ 'bower', '' ]
+12 verbose addNamed [ null, '*' ]
+13 silly lockFile 1240aab1-bower bower@
+14 verbose lock bower@ /Users/Gandhi/.npm/1240aab1-bower.lock
+15 silly addNameRange { name: 'bower', range: '*', hasData: false }
+16 verbose request where is /bower
+17 verbose request registry https://registry.npmjs.org/
+18 verbose request id b9f29fc3402b3182
+19 verbose url raw /bower
+20 verbose url resolving [ 'https://registry.npmjs.org/', './bower' ]
+21 verbose url resolved https://registry.npmjs.org/bower
+22 verbose request where is https://registry.npmjs.org/bower
+23 info trying registry request attempt 1 at 15:23:33
+24 http GET https://registry.npmjs.org/bower
+25 http 200 https://registry.npmjs.org/bower
+26 silly registry.get cb [ 200,
+26 silly registry.get   { date: 'Wed, 14 Jan 2015 20:23:33 GMT',
+26 silly registry.get     server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+26 silly registry.get     etag: '"EH3AKW8JH87ORRXQUVDJ9MISI"',
+26 silly registry.get     'content-type': 'application/json',
+26 silly registry.get     'cache-control': 'max-age=60',
+26 silly registry.get     'content-length': '106031',
+26 silly registry.get     'accept-ranges': 'bytes',
+26 silly registry.get     via: '1.1 varnish',
+26 silly registry.get     age: '5',
+26 silly registry.get     'x-served-by': 'cache-atl6226-ATL',
+26 silly registry.get     'x-cache': 'HIT',
+26 silly registry.get     'x-cache-hits': '1',
+26 silly registry.get     'x-timer': 'S1421267013.071015,VS0,VE1',
+26 silly registry.get     vary: 'Accept',
+26 silly registry.get     'keep-alive': 'timeout=10, max=50',
+26 silly registry.get     connection: 'Keep-Alive' } ]
+27 silly addNameRange number 2 { name: 'bower', range: '*', hasData: true }
+28 silly addNameRange versions [ 'bower',
+28 silly addNameRange   [ '0.1.0',
+28 silly addNameRange     '0.1.2',
+28 silly addNameRange     '0.1.3',
+28 silly addNameRange     '0.2.0',
+28 silly addNameRange     '0.3.0',
+28 silly addNameRange     '0.3.1',
+28 silly addNameRange     '0.3.2',
+28 silly addNameRange     '0.4.0',
+28 silly addNameRange     '0.5.0',
+28 silly addNameRange     '0.5.1',
+28 silly addNameRange     '0.6.0',
+28 silly addNameRange     '0.6.1',
+28 silly addNameRange     '0.6.2',
+28 silly addNameRange     '0.6.3',
+28 silly addNameRange     '0.6.4',
+28 silly addNameRange     '0.6.5',
+28 silly addNameRange     '0.6.6',
+28 silly addNameRange     '0.6.7',
+28 silly addNameRange     '0.6.8',
+28 silly addNameRange     '0.7.0',
+28 silly addNameRange     '0.7.1',
+28 silly addNameRange     '0.8.0',
+28 silly addNameRange     '0.8.1',
+28 silly addNameRange     '0.8.2',
+28 silly addNameRange     '0.8.3',
+28 silly addNameRange     '0.8.4',
+28 silly addNameRange     '0.8.5',
+28 silly addNameRange     '0.8.6',
+28 silly addNameRange     '0.9.0',
+28 silly addNameRange     '0.9.1',
+28 silly addNameRange     '0.9.2',
+28 silly addNameRange     '0.10.0',
+28 silly addNameRange     '1.0.0',
+28 silly addNameRange     '1.0.1',
+28 silly addNameRange     '1.0.2',
+28 silly addNameRange     '1.0.3',
+28 silly addNameRange     '1.1.0',
+28 silly addNameRange     '1.1.1',
+28 silly addNameRange     '1.1.2',
+28 silly addNameRange     '1.2.0',
+28 silly addNameRange     '1.2.1',
+28 silly addNameRange     '1.2.2',
+28 silly addNameRange     '1.2.3',
+28 silly addNameRange     '1.2.4',
+28 silly addNameRange     '1.2.5',
+28 silly addNameRange     '1.2.6',
+28 silly addNameRange     '1.2.7',
+28 silly addNameRange     '1.2.8',
+28 silly addNameRange     '1.3.0',
+28 silly addNameRange     '1.3.1',
+28 silly addNameRange     '1.3.2',
+28 silly addNameRange     '1.3.3',
+28 silly addNameRange     '1.3.4',
+28 silly addNameRange     '1.3.5',
+28 silly addNameRange     '1.3.6',
+28 silly addNameRange     '1.3.7',
+28 silly addNameRange     '1.3.8',
+28 silly addNameRange     '1.3.9',
+28 silly addNameRange     '1.3.10',
+28 silly addNameRange     '1.3.11',
+28 silly addNameRange     '1.3.12' ] ]
+29 verbose addNamed [ 'bower', '1.3.12' ]
+30 verbose addNamed [ '1.3.12', '1.3.12' ]
+31 silly lockFile 9819431c-bower-1-3-12 bower@1.3.12
+32 verbose lock bower@1.3.12 /Users/Gandhi/.npm/9819431c-bower-1-3-12.lock
+33 silly lockFile b05fd70b-npmjs-org-bower-bower-1-3-12-tgz https://registry.npmjs.org/bower/-/bower-1.3.12.tgz
+34 verbose lock https://registry.npmjs.org/bower/-/bower-1.3.12.tgz /Users/Gandhi/.npm/b05fd70b-npmjs-org-bower-bower-1-3-12-tgz.lock
+35 verbose addRemoteTarball [ 'https://registry.npmjs.org/bower/-/bower-1.3.12.tgz',
+35 verbose addRemoteTarball   '37de0edb3904baf90aee13384a1a379a05ee214c' ]
+36 info retry fetch attempt 1 at 15:23:33
+37 verbose fetch to= /var/folders/bj/h3fks1ws2_b9t22h00cctg9r0000gn/T/npm-21152-BbMHTJkP/registry.npmjs.org/bower/-/bower-1.3.12.tgz
+38 http GET https://registry.npmjs.org/bower/-/bower-1.3.12.tgz
+39 http 200 https://registry.npmjs.org/bower/-/bower-1.3.12.tgz
+40 silly lockFile b05fd70b-npmjs-org-bower-bower-1-3-12-tgz https://registry.npmjs.org/bower/-/bower-1.3.12.tgz
+41 silly lockFile b05fd70b-npmjs-org-bower-bower-1-3-12-tgz https://registry.npmjs.org/bower/-/bower-1.3.12.tgz
+42 silly lockFile 9819431c-bower-1-3-12 bower@1.3.12
+43 silly lockFile 9819431c-bower-1-3-12 bower@1.3.12
+44 silly lockFile 1240aab1-bower bower@
+45 silly lockFile 1240aab1-bower bower@
+46 silly resolved [ { name: 'bower',
+46 silly resolved     version: '1.3.12',
+46 silly resolved     description: 'The browser package manager',
+46 silly resolved     author: { name: 'Twitter' },
+46 silly resolved     licenses: [ [Object] ],
+46 silly resolved     repository: { type: 'git', url: 'https://github.com/bower/bower' },
+46 silly resolved     main: 'lib',
+46 silly resolved     homepage: 'http://bower.io',
+46 silly resolved     engines: { node: '>=0.10.0' },
+46 silly resolved     dependencies:
+46 silly resolved      { abbrev: '~1.0.4',
+46 silly resolved        archy: '0.0.2',
+46 silly resolved        'bower-config': '~0.5.2',
+46 silly resolved        'bower-endpoint-parser': '~0.2.2',
+46 silly resolved        'bower-json': '~0.4.0',
+46 silly resolved        'bower-logger': '~0.2.2',
+46 silly resolved        'bower-registry-client': '~0.2.0',
+46 silly resolved        cardinal: '0.4.0',
+46 silly resolved        chalk: '0.5.0',
+46 silly resolved        chmodr: '0.1.0',
+46 silly resolved        'decompress-zip': '0.0.8',
+46 silly resolved        fstream: '~1.0.2',
+46 silly resolved        'fstream-ignore': '~1.0.1',
+46 silly resolved        glob: '~4.0.2',
+46 silly resolved        'graceful-fs': '~3.0.1',
+46 silly resolved        handlebars: '~2.0.0',
+46 silly resolved        inquirer: '0.7.1',
+46 silly resolved        insight: '0.4.3',
+46 silly resolved        'is-root': '~1.0.0',
+46 silly resolved        junk: '~1.0.0',
+46 silly resolved        lockfile: '~1.0.0',
+46 silly resolved        'lru-cache': '~2.5.0',
+46 silly resolved        mkdirp: '0.5.0',
+46 silly resolved        mout: '~0.9.0',
+46 silly resolved        nopt: '~3.0.0',
+46 silly resolved        opn: '~1.0.0',
+46 silly resolved        osenv: '0.1.0',
+46 silly resolved        'p-throttler': '0.1.0',
+46 silly resolved        promptly: '0.2.0',
+46 silly resolved        q: '~1.0.1',
+46 silly resolved        request: '~2.42.0',
+46 silly resolved        'request-progress': '0.3.0',
+46 silly resolved        retry: '0.6.0',
+46 silly resolved        rimraf: '~2.2.0',
+46 silly resolved        semver: '~2.3.0',
+46 silly resolved        'shell-quote': '~1.4.1',
+46 silly resolved        'stringify-object': '~1.0.0',
+46 silly resolved        'tar-fs': '0.5.2',
+46 silly resolved        tmp: '0.0.23',
+46 silly resolved        'update-notifier': '0.2.0',
+46 silly resolved        which: '~1.0.5' },
+46 silly resolved     devDependencies:
+46 silly resolved      { coveralls: '~2.11.0',
+46 silly resolved        'expect.js': '~0.3.1',
+46 silly resolved        grunt: '~0.4.4',
+46 silly resolved        'grunt-cli': '^0.1.13',
+46 silly resolved        'grunt-contrib-jshint': '~0.10.0',
+46 silly resolved        'grunt-contrib-watch': '~0.6.1',
+46 silly resolved        'grunt-exec': '~0.4.2',
+46 silly resolved        'grunt-simple-mocha': '~0.4.0',
+46 silly resolved        istanbul: '~0.3.2',
+46 silly resolved        'load-grunt-tasks': '~0.6.0',
+46 silly resolved        mocha: '~1.21.4',
+46 silly resolved        nock: '~0.46.0',
+46 silly resolved        'node-uuid': '~1.4.1',
+46 silly resolved        proxyquire: '~1.0.1' },
+46 silly resolved     scripts: { test: 'grunt test' },
+46 silly resolved     bin: { bower: 'bin/bower' },
+46 silly resolved     preferGlobal: true,
+46 silly resolved     gitHead: 'b26c072f0db054a1902ec4d2e3726dbf8a1c799a',
+46 silly resolved     bugs: { url: 'https://github.com/bower/bower/issues' },
+46 silly resolved     _id: 'bower@1.3.12',
+46 silly resolved     _shasum: '37de0edb3904baf90aee13384a1a379a05ee214c',
+46 silly resolved     _from: 'bower@',
+46 silly resolved     _npmVersion: '2.0.0',
+46 silly resolved     _npmUser: { name: 'sheerun', email: 'sheerun@sher.pl' },
+46 silly resolved     maintainers: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
+46 silly resolved     dist:
+46 silly resolved      { shasum: '37de0edb3904baf90aee13384a1a379a05ee214c',
+46 silly resolved        tarball: 'http://registry.npmjs.org/bower/-/bower-1.3.12.tgz' },
+46 silly resolved     directories: {},
+46 silly resolved     _resolved: 'https://registry.npmjs.org/bower/-/bower-1.3.12.tgz' } ]
+47 info install bower@1.3.12 into /usr/local/lib
+48 info installOne bower@1.3.12
+49 verbose lib/node_modules/bower unbuild
+50 verbose tar unpack /Users/Gandhi/.npm/bower/1.3.12/package.tgz
+51 silly lockFile 1396471b-usr-local-lib-node-modules-bower tar:///usr/local/lib/node_modules/bower
+52 verbose lock tar:///usr/local/lib/node_modules/bower /Users/Gandhi/.npm/1396471b-usr-local-lib-node-modules-bower.lock
+53 silly lockFile f7218da3-dhi-npm-bower-1-3-12-package-tgz tar:///Users/Gandhi/.npm/bower/1.3.12/package.tgz
+54 verbose lock tar:///Users/Gandhi/.npm/bower/1.3.12/package.tgz /Users/Gandhi/.npm/f7218da3-dhi-npm-bower-1-3-12-package-tgz.lock
+55 silly gunzTarPerm modes [ '755', '644' ]
+56 error Error: EACCES, mkdir '/usr/local/lib/node_modules/bower'
+56 error  { [Error: EACCES, mkdir '/usr/local/lib/node_modules/bower']
+56 error   errno: 3,
+56 error   code: 'EACCES',
+56 error   path: '/usr/local/lib/node_modules/bower',
+56 error   fstream_type: 'Directory',
+56 error   fstream_path: '/usr/local/lib/node_modules/bower',
+56 error   fstream_class: 'DirWriter',
+56 error   fstream_stack:
+56 error    [ '/usr/local/lib/node_modules/npm/node_modules/fstream/lib/dir-writer.js:36:23',
+56 error      '/usr/local/lib/node_modules/npm/node_modules/mkdirp/index.js:46:53',
+56 error      'Object.oncomplete (fs.js:108:15)' ] }
+57 error Please try running this command again as root/Administrator.
+58 error System Darwin 14.0.0
+59 error command "node" "/usr/local/bin/npm" "install" "-g" "bower"
+60 error cwd /Applications/MAMP/htdocs/localhost/dante/Dante
+61 error node -v v0.10.35
+62 error npm -v 1.4.28
+63 error path /usr/local/lib/node_modules/bower
+64 error fstream_path /usr/local/lib/node_modules/bower
+65 error fstream_type Directory
+66 error fstream_class DirWriter
+67 error code EACCES
+68 error errno 3
+69 error stack Error: EACCES, mkdir '/usr/local/lib/node_modules/bower'
+70 error fstream_stack /usr/local/lib/node_modules/npm/node_modules/fstream/lib/dir-writer.js:36:23
+70 error fstream_stack /usr/local/lib/node_modules/npm/node_modules/mkdirp/index.js:46:53
+70 error fstream_stack Object.oncomplete (fs.js:108:15)
+71 verbose exit [ 3, true ]


### PR DESCRIPTION
Introduces basic list support using smart shortcuts. "- ", "1. ", and "1) " can be used at the start of a paragraph to convert it into an unordered or ordered list on the next spacebar or enter keydown. Backspace in the first list item will remove it from the list into its own paragraph. Enter on the last child will break into a new paragraph if that child was empty. 

To-Do:
-Hide media "+" button in empty lists
-Introduce insert (un)ordered list buttons to the pop-up menu
-Merging consecutive lists, as well as split a list into two separate lists.
-Allow Lists to be entered at editor creation (They are currently converted to paragraphs)