### PR TITLE
Force secure download of Google fonts for editor

### DIFF
--- a/app/assets/stylesheets/dante/_fonts.scss
+++ b/app/assets/stylesheets/dante/_fonts.scss
@@ -14,4 +14,4 @@
 @include dante-font-face(dante, fontello);
 @include dante-font-face(dante-tooltip, dante);
 
-@import url(http://fonts.googleapis.com/css?family=Merriweather:400,700,400italic,700italic|Open+Sans:400,300,800);
+@import url(https://fonts.googleapis.com/css?family=Merriweather:400,700,400italic,700italic|Open+Sans:400,300,800);

--- a/app/assets/stylesheets/dante/_fonts.scss
+++ b/app/assets/stylesheets/dante/_fonts.scss
@@ -14,4 +14,4 @@
 @include dante-font-face(dante, fontello);
 @include dante-font-face(dante-tooltip, dante);
 
-@import url(https://fonts.googleapis.com/css?family=Merriweather:400,700,400italic,700italic|Open+Sans:400,300,800);
+@import url('//fonts.googleapis.com/css?family=Merriweather:400,700,400italic,700italic|Open+Sans:400,300,800');


### PR DESCRIPTION
Love the editor, its really great, I have used it in a number of personal projects. However I am now including it in a public application (my blog) and it (the blog) uses ssl. 

This means that I need to load all the scripts with `https` rather than `http` and this project loads the google font the wrong way. (It took me a while to work out which gem was doing so.)

Hopefully no one objects to this and it doesn't cause any problems.