### PR TITLE
Fix collapse inline tooltip

### DIFF
--- a/app/assets/javascripts/dante/tooltip.js.coffee
+++ b/app/assets/javascripts/dante/tooltip.js.coffee
@@ -34,8 +34,20 @@ class Dante.Editor.Tooltip extends Dante.View
 
 
   render: ()=>
-    $(@el).html(@template())
-    $(@el).addClass("is-active")
+    tooltip = $(@el)
+    tooltip.html(@template())
+    tooltip.addClass("is-active")
+
+    # Set menu size
+    tooltip_menu           = tooltip.find(".inlineTooltip-menu")
+    tooltip_buttons        = tooltip_menu.find(".inlineTooltip-button")
+    tooltip_button_width   = $(tooltip_buttons[0]).css("width")
+    tooltip_button_spacing = $(tooltip_buttons[0]).css("margin-right")
+    tooltip_button_size    = parseInt(tooltip_button_width.replace(/px/,"")) + parseInt(tooltip_button_spacing.replace(/px/,""))
+    tooltip_menu_size      = tooltip_button_size * tooltip_buttons.length
+
+    # Add 1px on expanded tooltip to avoid colapsed buttons in FF
+    tooltip_menu.css("width", "#{tooltip_menu_size + 1}px")
     @
 
   toggleOptions: ()=>

--- a/app/assets/stylesheets/dante/_tooltip.scss
+++ b/app/assets/stylesheets/dante/_tooltip.scss
@@ -20,17 +20,14 @@
   &.is-scaled {
     -webkit-transition-delay: 0;
     transition-delay: 0;
+    width: auto;
   }
 }
 
 // MENU
 .inlineTooltip-menu {
-  & {
-    width: $tooltip-size-expanded;
-  }
-  button {
-    margin-right: $tooltip-button-spacing;
-  }
+  display: inline-block;
+  margin-left: $tooltip-size + $tooltip-menu-spacing;
 }
 
 // BUTTON
@@ -39,7 +36,7 @@
   // BASE
   & {
     float: left;
-    margin-right: $tooltip-menu-spacing;
+    margin-right: $tooltip-button-spacing;
     display: inline-block;
     position: relative;
     outline: 0;
@@ -105,6 +102,11 @@
 
   // CONTROL
   &.control {
+    & {
+      display: block;
+      position: absolute;
+      margin-right: $tooltip-menu-spacing;
+    }
     & {
       -webkit-transition: -webkit-#{$tooltip-forward-transition}, $tooltip-default-transition;
               transition: $tooltip-forward-transition, $tooltip-default-transition;

--- a/app/assets/stylesheets/dante/_variables.scss
+++ b/app/assets/stylesheets/dante/_variables.scss
@@ -80,15 +80,13 @@ $tooltip-border-radius:         999em;
 $tooltip-button-spacing:        9px;
 $tooltip-menu-spacing:          22px;
 
-$tooltip-items:                 3;
+$tooltip-items:                 10; // Fix this and remove it
 $tooltip-item-delay:            30;
 $tooltip-size:                  32px;
 $tooltip-line-height:           $tooltip-size;
 
 $tooltip-caret-size:            12px;
 
-// Add 1px on expanded tooltip to avoid colapsed buttons in FF
-$tooltip-size-expanded:         1 + ($tooltip-size + $tooltip-menu-spacing) + (($tooltip-size + $tooltip-button-spacing) * $tooltip-items);
 $tooltip-default-transition:    100ms border-color, 100ms color;
 $tooltip-forward-transition:    transform 100ms;
 $tooltip-backward-transition:   transform 250ms;


### PR DESCRIPTION
To prevent shit happens when collapse `.inlineTooltio`
<img width="611" alt="captura de pantalla 2016-06-15 a las 11 09 41" src="https://cloud.githubusercontent.com/assets/627694/16083495/8d42af8e-32eb-11e6-96d1-c6312cf28676.png">
