### PR TITLE
Hotfix/classes to menu items

### DIFF
--- a/packages/dante3/src/App.js
+++ b/packages/dante3/src/App.js
@@ -1,4 +1,3 @@
-import logo from "./logo.svg";
 import "./App.css";
 import Editor from "./DanteEditor";
 

--- a/packages/dante3/src/DanteEditor.js
+++ b/packages/dante3/src/DanteEditor.js
@@ -1,17 +1,4 @@
-import React, { useEffect, useState } from "react";
-//import { getNodeType } from "@tiptap/core";
-import {
-  useEditor,
-  EditorContent,
-  FloatingMenu,
-  ReactNodeViewRenderer,
-} from "@tiptap/react";
-
-import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import TextStyle from "@tiptap/extension-text-style";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import Focus from "@tiptap/extension-focus";
+import React, { useState } from "react";
 
 //import './styles.scss'
 import { ThemeProvider } from "@emotion/react";
@@ -20,14 +7,14 @@ import darkTheme from "./styled/themes/dark";
 
 import { ImageBlockConfig } from "./blocks/image";
 import { VideoRecorderBlockConfig } from "./blocks/videoRecorder";
-import CodeBlock, { CodeBlockConfig } from "./blocks/code";
+import { CodeBlockConfig } from "./blocks/code";
 import { PlaceholderBlockConfig } from "./blocks/placeholder";
 import { DividerBlockConfig } from "./blocks/divider";
 import { GiphyBlockConfig } from "./blocks/giphy/giphyBlock";
 import { EmbedBlockConfig } from "./blocks/embed";
 import { VideoBlockConfig } from "./blocks/video";
 
-import defaultContent, { jsonContent } from "./data/content";
+import { jsonContent } from "./data/content";
 // load all highlight.js languages
 import lowlight from "lowlight";
 //import SaveBehavior from './data/save_content'
@@ -52,6 +39,7 @@ export default function Editor() {
   const [log, setLog] = useState(null);
   const [theme, setTheme] = useState("light");
   const [fixed, setFixed] = useState(false);
+  const [hasPopOver, setHasPopOver] = useState(false);
 
   const [themeOptions, setThemeOptions] = useState(getDefaultTheme());
 
@@ -147,6 +135,7 @@ export default function Editor() {
           appendPlugins={optionalPlugins}
           theme={themeOptions}
           fixed={fixed}
+          hasPopOver={hasPopOver}
           content={jsonContent}
         />
       </EditorContainer>

--- a/packages/dante3/src/editor/index.tsx
+++ b/packages/dante3/src/editor/index.tsx
@@ -6,6 +6,7 @@ import {
   FloatingMenu,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
+import { Editor as IEditor } from "@tiptap/core";
 
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
@@ -36,16 +37,26 @@ import lowlight from "lowlight";
 //import SaveBehavior from './data/save_content'
 import EditorContainer, { LogWrapper } from "../styled/base";
 
+interface Props extends Record<string, any> {
+  fixed: boolean;
+  hasPopOver: boolean;
+  content: string;
+  onUpdate: (args: IEditor) => void;
+  readOnly: boolean;
+  bodyPlaceholder: string;
+}
+
 export default function Editor({
   widgets,
   theme,
-  fixed,
+  fixed = false,
+  hasPopOver = true,
   content,
   onUpdate,
   readOnly,
   bodyPlaceholder,
   extensions,
-}) {
+}: Props) {
   function basePlugins() {
     return [
       StarterKit.configure({
@@ -131,10 +142,11 @@ export default function Editor({
 
   //window.editor = editor;
 
-  function isPopOverEnabledFor(a) {
+  function isPopOverEnabled() {
     //console.log("ENABLED FOR ", editor.state.selection.$anchor.parent);
     const comp = editor.state.selection.$anchor.parent;
-    if (comp.type.name === "paragraph") return true;
+
+    return comp.type.name === "paragraph" && hasPopOver;
   }
 
   const resolvedTheme = theme ? theme : defaultTheme;
@@ -155,7 +167,7 @@ export default function Editor({
 
           {editor && !fixed && (
             <FloatingMenu editor={editor}>
-              {isPopOverEnabledFor("AddButton") && (
+              {isPopOverEnabled() && (
                 <div style={{ position: "absolute", top: -15, left: -60 }}>
                   <AddButton
                     //ref={sideBarControls}

--- a/packages/dante3/src/popovers/addButton.tsx
+++ b/packages/dante3/src/popovers/addButton.tsx
@@ -91,8 +91,8 @@ const AddButton = React.forwardRef(
       editor.commands.insertContent({
         type: "PlaceholderBlock",
         attrs: {
-          blockKind: block
-        }
+          blockKind: block,
+        },
       });
       console.log("placeholder: to be implemented", block);
     }
@@ -100,7 +100,7 @@ const AddButton = React.forwardRef(
     function handleInsertion(block) {
       editor.commands.insertContent({
         type: block.name,
-        attrs: {}
+        attrs: {},
       });
       console.log("insertion: to be implemented", block);
     }
@@ -128,7 +128,7 @@ const AddButton = React.forwardRef(
 
       let opts = {
         url: URL.createObjectURL(file),
-        file
+        file,
       };
       // cleans input image value
       fileInput.current.value = "";
@@ -142,8 +142,8 @@ const AddButton = React.forwardRef(
         type: "ImageBlock",
         attrs: {
           file: file,
-          url: URL.createObjectURL(file)
-        }
+          url: URL.createObjectURL(file),
+        },
       });
     }
 
@@ -215,7 +215,7 @@ function InlineTooltipItem({ item, clickHandler, title }) {
   return (
     <button
       type="button"
-      className="inlineTooltip-button scale"
+      className={`inlineTooltip-button inlineTooltip-button--${item.tag} scale`}
       title={title}
       onMouseDown={onMouseDown}
       onClick={(e) => e.preventDefault()}

--- a/packages/dante3/src/popovers/bubble-menu/bubble-menu-extension/bubble-menu-plugin.ts
+++ b/packages/dante3/src/popovers/bubble-menu/bubble-menu-extension/bubble-menu-plugin.ts
@@ -89,6 +89,7 @@ export class BubbleMenuView {
       getReferenceClientRect: null,
       content: this.element,
       interactive: true,
+      maxWidth: "",
       trigger: "manual",
       placement: "top",
       hideOnClick: "toggle",
@@ -128,24 +129,25 @@ export class BubbleMenuView {
     // IF PASS SET DISABLED HERE
     this.enabled = false;
 
-    this.tippy && this.tippy.setProps({
-      getReferenceClientRect: () => {
-        if (isNodeSelection(view.state.selection)) {
-          const node = view.nodeDOM(from) as HTMLElement;
+    this.tippy &&
+      this.tippy.setProps({
+        getReferenceClientRect: () => {
+          if (isNodeSelection(view.state.selection)) {
+            const node = view.nodeDOM(from) as HTMLElement;
 
-          if (node && node.getBoundingClientRect) {
-            // return node.getBoundingClientRect()
-            if (node.children[0]) {
-              return node.children[0].getBoundingClientRect(); // THIS
-            } else {
-              return node.getBoundingClientRect();
+            if (node && node.getBoundingClientRect) {
+              // return node.getBoundingClientRect()
+              if (node.children[0]) {
+                return node.children[0].getBoundingClientRect(); // THIS
+              } else {
+                return node.getBoundingClientRect();
+              }
             }
           }
-        }
 
-        return posToDOMRect(view, from, to);
-      },
-    });
+          return posToDOMRect(view, from, to);
+        },
+      });
 
     this.show();
   }
@@ -160,7 +162,7 @@ export class BubbleMenuView {
 
   destroy() {
     this.tippy.destroy();
-    this.tippy = null
+    this.tippy = null;
     this.element.removeEventListener("mousedown", this.mousedownHandler);
     this.view.dom.removeEventListener("mouseup", this.mouseupHandler); // <-- REMOVE THE EVENT
     this.editor.off("focus", this.focusHandler);

--- a/packages/dante3/src/popovers/color.js
+++ b/packages/dante3/src/popovers/color.js
@@ -60,7 +60,7 @@ export default function DanteTooltipColor(props) {
   }
 
   return (
-    <li className="dante-menu-button">
+    <li className="dante-menu-button dante-menu-button--color">
       <span className={"dante-icon"} onMouseDown={toggle}>
         {fontColor()}
       </span>

--- a/packages/dante3/src/popovers/menuBar.js
+++ b/packages/dante3/src/popovers/menuBar.js
@@ -16,7 +16,6 @@ import {
   h1,
   h2,
   h3,
-  h4,
   blockquote,
   code,
 } from "../icons";
@@ -32,7 +31,7 @@ function DanteTooltipLink({ enableLinkMode, selected }) {
 
   return (
     <li
-      className={`dante-menu-button ${selected ? "active" : ""}`}
+      className={`dante-menu-button dante-menu-button--link ${selected && "active"}`}
       onMouseDown={promptForLink}
     >
       <span className={"dante-icon"}>{link()}</span>
@@ -57,9 +56,9 @@ export default function MenuBar({ editor, fixed }) {
   function displayLinkMode() {
     if (linkState.link_mode) {
       return "dante-menu--linkmode";
-    } else {
-      return "";
     }
+
+    return "";
   }
 
   function displayActiveMenu() {
@@ -70,10 +69,10 @@ export default function MenuBar({ editor, fixed }) {
     }
   }
 
-  function itemClass(kind, opts = null) {
-    if (!opts)
-      return `dante-menu-button ${editor.isActive(kind) ? "active" : ""}`;
-    return `dante-menu-button ${editor.isActive(kind, opts) ? "active" : ""}`;
+  function itemClass(kind, opts) {
+    const hasOptions = opts && `-${Object.values(opts)[0]}`;
+
+    return `dante-menu-button dante-menu-button--${kind}${hasOptions} ${editor.isActive(kind, opts) && "active"}`;
   }
 
   function handleInputEnter(e) {
@@ -117,8 +116,9 @@ export default function MenuBar({ editor, fixed }) {
   }
 
   function fixedStyles() {
-    if (!fixed) return { width: `${11 * 43}px` };
-    if (fixed) return { position: `sticky`, top: "0" };
+    if (!fixed) return { width: 'max-content' };
+
+    return { position: `sticky`, top: "0" };
   }
 
   function renderMenu() {
@@ -131,19 +131,19 @@ export default function MenuBar({ editor, fixed }) {
         className={`dante-menu ${displayLinkMode()}`}
         style={fixedStyles()}
       >
-        <div className="dante-menu-linkinput" style={{ width: `${11 * 43}px` }}>
+        <div className="dante-menu-linkinput">
           <input
             className="dante-menu-input"
             placeholder={"put your souce here"}
             onKeyPress={handleInputEnter}
-            //defaultValue={ this.getDefaultValue() }
+          //defaultValue={ this.getDefaultValue() }
           />
           <div className="dante-menu-button" onMouseDown={_disableLinkMode}>
             <span className={"dante-icon"}>{close()}</span>
           </div>
         </div>
 
-        <div className="dante-menu-buttons" style={linkState.menu_style}>
+        <ul className="dante-menu-buttons" style={linkState.menu_style}>
           <li
             onClick={() => editor.chain().focus().toggleBold().run()}
             className={itemClass("bold")}
@@ -220,7 +220,7 @@ export default function MenuBar({ editor, fixed }) {
           >
             <span className={"dante-icon"}>{blockquote()}</span>
           </li>
-        </div>
+        </ul>
       </AnchorStyle>
     );
   }

--- a/packages/dante3/src/styled/menu.js
+++ b/packages/dante3/src/styled/menu.js
@@ -29,6 +29,7 @@ export const AnchorStyle = styled.div`
   // &:after  -> Triangulo
 
   &.dante-menu {
+    position: relative;
     &:after {
       content: "";
       height: 0;
@@ -223,16 +224,16 @@ export const AnchorStyle = styled.div`
 
     &:first-of-type {
       border-top-left-radius: ${(props) =>
-        props.theme.dante_menu_border_radius};
+    props.theme.dante_menu_border_radius};
       border-bottom-left-radius: ${(props) =>
-        props.theme.dante_menu_border_radius};
+    props.theme.dante_menu_border_radius};
       padding-left: 18px;
     }
     &:last-child {
       border-top-right-radius: ${(props) =>
-        props.theme.dante_menu_border_radius};
+    props.theme.dante_menu_border_radius};
       border-bottom-right-radius: ${(props) =>
-        props.theme.dante_menu_border_radius};
+    props.theme.dante_menu_border_radius};
       padding-right: 18px;
     }
   }
@@ -268,7 +269,8 @@ export const AnchorStyle = styled.div`
     top: 0;
     left: 0;
     width: 100%;
-    padding: 13px 40px 13px 10px;
+    height: 100%;
+    padding: 0 40px 0 10px;
     color: ${(props) => props.theme.dante_menu_color};
     background: transparent;
     border: none;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,43 +1,43 @@
 import Layout from '../components/Layout'
-import {Component, useEffect, useState} from 'react'
+import { Component, useEffect, useState } from 'react'
 
 import Dante, {
-  darkTheme, 
-  defaultTheme, 
+  darkTheme,
+  defaultTheme,
   defaultPlugins
 } from '../packages/dante3/src' //
 // from '../packages/dante3'
 
-import { contentDemo as htmlContent} from "../packages/dante3/src/data/content";
+import { contentDemo as htmlContent } from "../packages/dante3/src/data/content";
 
-import {version, name} from '../packages/dante3/package.json'
+import { version, name } from '../packages/dante3/package.json'
 
 export default function Index({ }) {
   const [theme, setTheme] = useState(defaultTheme)
   const [mode, setMode] = useState('light')
   const [fixed, setFixed] = useState(false)
 
-  function onClick(m){
+  function onClick(m) {
     console.log(m)
     const t = m == 'dark' ? darkTheme : defaultTheme
-    setTheme( t )
+    setTheme(t)
     setMode(m)
   }
 
-  useEffect(()=>{
+  useEffect(() => {
     setTheme(mode === 'light' ? defaultTheme : darkTheme)
   }, [mode])
 
   return (
-    <Layout 
+    <Layout
       version={version}
       name={name}
-      theme={theme} 
-      setTheme={setTheme} 
+      theme={theme}
+      setTheme={setTheme}
       mode={mode}
       setMode={setMode}>
-      
-      <div className={`sm:mx-10 mx-2 py-8 ${mode}`} 
+
+      <div className={`sm:mx-10 mx-2 py-8 ${mode}`}
         heme={theme}>
         <div>
           <div className={`sm:w-3/4 p-10 md:mx-auto shadow-md- bg-gray-50- dark:bg-black light`}>
@@ -51,10 +51,11 @@ export default function Index({ }) {
               {mode === 'dark' ? 'light mode' : 'dark mode'}
             </button>*/}
 
-            <Dante 
+            <Dante
               widgets={defaultPlugins}
               theme={theme}
               fixed={fixed}
+              hasPopOver={true}
               content={htmlContent}
               /*widgets={[
                 ImageBlockConfig(),
@@ -66,17 +67,17 @@ export default function Index({ }) {
                 VideoRecorderBlockConfig()
               ]}*/
               style={{}}
-              read_only={false}
+              readOnly={false}
               onUpdate={
-                (editor)=>{
+                (editor) => {
                   console.log("content", editor.getHTML())
                   //console.log("content", JSON.stringify(editor.getJSON()))
                 }
               }
-              data_storage={ 
+              data_storage={
                 {
                   interval: 10000,
-                  save_handler: (context, content)=>{
+                  save_handler: (context, content) => {
                     //console.log(context, content)
                   }
                 }


### PR DESCRIPTION
Remove some unused imports, theres still a bunch of functions and commented code that can be cleaned up

Prop to hide left popover menu, along with some basic interface for the typings on just the main properties, i don't know what would be the types for all the other properties i missed

Fixed some hardcoded widths with css

Menu items now have a individual classname

Fixed css of hyperlink input not centering correctly

Lint fixes

And some basic other improvements on ifs and stuff

Fixes michelson/Dante#182